### PR TITLE
[ch2574] [`GenericModel`] `pivots` não incluídos na saída do `.toJSON`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.5 (2021-06-24)
+
+
+### Code Refactoring
+
+* [`GenericModel`] `pivots` não incluídos na saída do `.toJSON`
+
 ## 0.4.4 (2021-03-08)
 
 

--- a/lib/GenericModel.js
+++ b/lib/GenericModel.js
@@ -397,7 +397,10 @@ class GenericModel extends bookshelf.Model {
   }
 
   _getPivots(object) {
-    const pivots = {}
+    let pivots = {}
+
+    if (this.pivot)
+      pivots = { ...this.pivot.attributes }
 
     for (const attr in object) {
       if (attr.startsWith('_pivot_'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generic-model-bookshelf",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Generic model for bookshelf (ORM)",
   "main": "lib/GenericModel.js",
   "directories": {


### PR DESCRIPTION
refactor: [`GenericModel`] `pivots` não incluídos na saída do `.toJSON`